### PR TITLE
Add GitHub Actions workflows for tests and PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.8"
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    
+    - name: Build package
+      run: python -m build
+    
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: twine upload dist/* 


### PR DESCRIPTION
   This PR adds GitHub Actions workflows for:
   
   - Continuous Integration (CI):
     - Running tests on multiple Python versions
     - Code coverage reporting with Codecov
     - Type checking with mypy
   
   - Continuous Deployment (CD):
     - Automated PyPI publishing on new releases
   
   The workflows will help maintain code quality and automate the release process.